### PR TITLE
Revert "small correction to makedoc.g"

### DIFF
--- a/makedoc.g
+++ b/makedoc.g
@@ -5,7 +5,7 @@ if fail = LoadPackage("AutoDoc", "2022.07.10") then
     Error("AutoDoc version 2022.07.10 or newer is required.");
 fi;
 
-AutoDoc( "coco2p", rec(
+AutoDoc( rec(
     autodoc := true,
     #extract_examples := true,
     gapdoc := rec( main := "coco.xml" ),


### PR DESCRIPTION
This is actually incorrect. Very old versions of AutoDoc required an initial argument, but this is not necessary anymore and in fact discouraged.

If you did this to fix a problem, please let me know what the problem is, and we can find a proper solution :-)